### PR TITLE
Optionally filter by release_type and bundle_short_version

### DIFF
--- a/lib/fastlane/plugin/latest_hockey_build_number/actions/latest_hockey_build_number_action.rb
+++ b/lib/fastlane/plugin/latest_hockey_build_number/actions/latest_hockey_build_number_action.rb
@@ -31,10 +31,15 @@ module Fastlane
         details_response = http.request(details_request)
 
         app_details = JSON.parse(details_response.body)
-        latest_build = app_details['app_versions'][0]
+
+        bundle_short_version = config[:bundle_short_version]
+        app_details = app_details.select { |app_version| app_version['shortversion'] } unless bundle_short_version.nil?
+
+        latest_build = app_details['app_versions'].first
 
         if latest_build.nil?
-          UI.error "The app has no versions yet"
+          bundle_short_version_message = bundle_short_version.nil? ? "" : " for #{bundle_short_version}"
+          UI.error "The app has no versions yet" + bundle_short_version_message
           return nil
         end
 
@@ -65,7 +70,11 @@ module Fastlane
                                        end),
           FastlaneCore::ConfigItem.new(key: :release_type,
                                      env_name: "FL_HOCKEY_RELEASE_TYPE",
-                                     description: "Release type of the app: \"0\" = Beta, \"1\" = Store, \"2\" = Alpha, \"3\" = Enterprise",
+                                     description: "Release type of the app: \"0\" = Beta, \"1\" = Store, \"2\" = Alpha, \"3\" = Enterprise. Used as an additional filter for the app list",
+                                     optional: true),
+          FastlaneCore::ConfigItem.new(key: :bundle_short_version,
+                                     env_name: "FL_HOCKEY_BUNDLE_SHORT_VERSION",
+                                     description: "The bundle_short_version of your application. Used as an additional filter for the version list",
                                      optional: true)
         ]
       end

--- a/lib/fastlane/plugin/latest_hockey_build_number/actions/latest_hockey_build_number_action.rb
+++ b/lib/fastlane/plugin/latest_hockey_build_number/actions/latest_hockey_build_number_action.rb
@@ -31,11 +31,12 @@ module Fastlane
         details_response = http.request(details_request)
 
         app_details = JSON.parse(details_response.body)
+        app_versions = app_details['app_versions']
 
         bundle_short_version = config[:bundle_short_version]
-        app_details = app_details.select { |app_version| app_version['shortversion'] } unless bundle_short_version.nil?
+        app_versions = app_versions.select { |app_version| app_version['shortversion'] == bundle_short_version } unless bundle_short_version.nil?
 
-        latest_build = app_details['app_versions'].first
+        latest_build = app_versions.first
 
         if latest_build.nil?
           bundle_short_version_message = bundle_short_version.nil? ? "" : " for #{bundle_short_version}"
@@ -74,7 +75,7 @@ module Fastlane
                                      optional: true),
           FastlaneCore::ConfigItem.new(key: :bundle_short_version,
                                      env_name: "FL_HOCKEY_BUNDLE_SHORT_VERSION",
-                                     description: "The bundle_short_version of your application. Used as an additional filter for the version list",
+                                     description: "The bundle_short_version of your application. Used as an additional filter for the version list. Caution filters short version only for 1st page resutls",
                                      optional: true)
         ]
       end

--- a/lib/fastlane/plugin/latest_hockey_build_number/version.rb
+++ b/lib/fastlane/plugin/latest_hockey_build_number/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module LatestHockeyBuildNumber
-    VERSION = "0.1.0"
+    VERSION = "0.1.2"
   end
 end


### PR DESCRIPTION
The current implementation chooses the 1st matching bundle id in the app list. I have a use case where both the release and beta versions use the same bundle id and the wrong version is chosen.

I've added an optional parameter, `release_type`,  to filter the app list base on the release type.

I have another use case where I am interested in getting the latest version number for a specific bundle short version, i.e. "1.1.0". So, I added a 2nd optional filtering parameter: `bundle_short_version`.

Thank you for the great plugin!